### PR TITLE
Ignore tests for release bundle. Fixed php-cs-fixer name as well

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,7 @@
+/tests export-ignore
 /.gitattributes export-ignore
 /.github export-ignore
 /.gitignore export-ignore
-/.php_cs.dist export-ignore
+/.php-cs-fixer.dist.php export-ignore
 /phpstan.neon.dist export-ignore
 /phpunit.xml.dist export-ignore


### PR DESCRIPTION
* `tests/` directory is not ignored which is weird.
* there is no `.php_cs.dist` but there is php-cs-fixer config instead :)

![image](https://user-images.githubusercontent.com/671925/205167581-1bbdcffa-a224-4e26-bc56-960792bc40e2.png)
